### PR TITLE
Add UMM Settings UI with Granular Tuning and Scaling Support

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Reflection;
+using AttributeFeats.New_Feats;          
 using HarmonyLib;
-using Kingmaker.Blueprints.JsonSystem;   // ✅ 关键：BlueprintsCache 在这里
+using Kingmaker.Blueprints.JsonSystem;  
+using Kingmaker.UnitLogic.Mechanics.Components;
+using UnityEngine;
 using UnityModManagerNet;
-using AttributeFeats.New_Feats;          // ✅ 你的 ConfigureAll 在这里
 
 namespace AttributeFeats
 {
@@ -12,15 +14,20 @@ namespace AttributeFeats
 		internal static Harmony HarmonyInstance;
 		internal static UnityModManager.ModEntry.ModLogger Log;
 		internal static UnityModManager.ModEntry Entry;
+		internal static ModSettings Settings;
 
-		public static bool Enabled = true;   // 默认启用；UMM toggle 只是给你个开关
+
+		public static bool Enabled = true;  
+
 
 		public static bool Load(UnityModManager.ModEntry modEntry)
 		{
-			Entry = modEntry;
 			Log = modEntry.Logger;
+			Settings = UnityModManager.ModSettings.Load<ModSettings>(modEntry);
 
 			modEntry.OnToggle = OnToggle;
+			modEntry.OnGUI = OnGUI;
+			modEntry.OnSaveGUI = OnSaveGUI;
 
 			HarmonyInstance = new Harmony(modEntry.Info.Id);
 			HarmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
@@ -35,6 +42,57 @@ namespace AttributeFeats
 			Log.Log(value ? "AttributeFeats enabled." : "AttributeFeats disabled (restart required to fully unload).");
 			return true;
 		}
+
+		private static void OnSaveGUI(UnityModManager.ModEntry modEntry)
+		{
+			Settings.Save(modEntry);
+		}
+
+		static void OnGUI(UnityModManager.ModEntry modEntry)
+		{
+			var s = Settings;
+			GUILayout.Label("<color=cyan><b>[ Global Scaling Configuration ] - Restart Required</b></color>");
+
+			GUILayout.BeginVertical("box");
+			GUILayout.BeginHorizontal();
+			GUILayout.Label($"Global Progression Mode: <color=yellow>{s.progression}</color>", GUILayout.Width(300));
+			GUILayout.FlexibleSpace();
+			if (GUILayout.Button("Cycle Ratio", GUILayout.Width(120)))
+			{
+				s.progression = s.progression switch
+				{
+					ContextRankProgression.AsIs => ContextRankProgression.Div2,
+					ContextRankProgression.Div2 => ContextRankProgression.HalfMore,
+					_ => ContextRankProgression.AsIs
+				};
+			}
+			GUILayout.EndHorizontal();
+			GUILayout.Label($"<color=grey><size=11>Current Effect: {GetDescription(s.progression)}</size></color>");
+			GUILayout.EndVertical();
+
+			GUILayout.Space(10);
+
+			GUILayout.Label("<color=cyan><b>[ Feature Toggles ]</b></color>");
+			GUILayout.BeginVertical("box");
+			s.EnableAttributes = GUILayout.Toggle(s.EnableAttributes, " Ability Score Stacking (e.g., Con added to Str)");
+			s.EnableBattles = GUILayout.Toggle(s.EnableBattles, " Combat Stats (AC, BAB, Initiative, HP)");
+			s.EnableSavings = GUILayout.Toggle(s.EnableSavings, " Saving Throws (Fortitude, Reflex, Will)");
+			s.EnableChecks = GUILayout.Toggle(s.EnableChecks, " Attribute Checks (Bluff, Diplomacy, etc.)");
+			s.EnableSkills = GUILayout.Toggle(s.EnableSkills, " Skill Proficiencies (Athletics, Perception, etc.)");
+			s.EnableCaster = GUILayout.Toggle(s.EnableCaster, " Caster Progression (DC, CL, Echo Spell, All Spell Lists)");
+			GUILayout.EndVertical();
+
+			if (GUI.changed) { Settings.Save(modEntry); }
+		}
+
+		private static string GetDescription(ContextRankProgression p) => p switch
+		{
+			ContextRankProgression.AsIs => "100% (1:1 Ratio)",
+			ContextRankProgression.Div2 => "50% (2:1 Ratio - Balanced)",
+			ContextRankProgression.HalfMore => "150% (1:1.5 Ratio - Overpowered)",
+			_ => p.ToString()
+		};
+
 
 		[HarmonyPatch(typeof(BlueprintsCache))]
 		private static class BlueprintsCache_Patch

--- a/New_Feats/AttributeFeats.cs
+++ b/New_Feats/AttributeFeats.cs
@@ -12,6 +12,7 @@ using Kingmaker.Designers.Mechanics.Facts;
 using Kingmaker.ElementsSystem;
 using Kingmaker.EntitySystem.Stats;
 using Kingmaker.Enums;
+using Kingmaker.Globalmap.State.InputManager;
 using Kingmaker.Localization;
 using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Abilities;
@@ -20,6 +21,7 @@ using Kingmaker.UnitLogic.FactLogic;
 using Kingmaker.UnitLogic.Mechanics;
 using Kingmaker.UnitLogic.Mechanics.Actions;
 using Kingmaker.UnitLogic.Mechanics.Components;
+using UnityModManagerNet;
 
 namespace AttributeFeats.New_Feats
 {
@@ -33,11 +35,30 @@ namespace AttributeFeats.New_Feats
 		public const string cha_main_to_everything = "e16525c7-ec29-4904-a69c-8b35f0c60a95";
 	}
 
+	public class ModSettings : UnityModManager.ModSettings
+	{
+		public bool EnableAttributes = true;
+		public bool EnableBattles = true;
+		public bool EnableSavings = true;
+		public bool EnableChecks = true;
+		public bool EnableSkills = true;
+		public bool EnableCaster = true;
+
+
+		public ContextRankProgression progression = ContextRankProgression.AsIs;
+
+		public override void Save(UnityModManager.ModEntry modEntry)
+		{
+			Save(this, modEntry);
+		}
+	}
+
+
 	internal static class MainAbilityToEverything_Feats
 	{
 		private static readonly ModifierDescriptor Desc = ModifierDescriptor.Inherent;
 
-		private static readonly StatType[] AbilityStats = new[]
+		private static readonly StatType[] AttributeStats = new[]
 		{
 			StatType.Strength,
 			StatType.Dexterity,
@@ -45,21 +66,37 @@ namespace AttributeFeats.New_Feats
 			StatType.Intelligence,
 			StatType.Wisdom,
 			StatType.Charisma,
-
+		};
+		private static readonly StatType[] BattleStats = new[]
+		{
+			StatType.BaseAttackBonus,
+			StatType.AdditionalAttackBonus,
+			StatType.AdditionalDamage,
+			StatType.AttackOfOpportunityCount,
 			StatType.AC,
+			StatType.AdditionalCMB,
+			StatType.AdditionalCMD,
 
+			StatType.HitPoints,
 			StatType.Initiative,
-
+			StatType.Speed,
+			StatType.SneakAttack,
+			StatType.Reach,
+		};
+		private static readonly StatType[] SaveStats = new[]
+		{
 			StatType.SaveFortitude,
 			StatType.SaveReflex,
 			StatType.SaveWill,
-
-			StatType.Speed,
-
+		};
+		private static readonly StatType[] CheckStats = new[]
+		{
 			StatType.CheckBluff,
 			StatType.CheckDiplomacy,
 			StatType.CheckIntimidate,
-
+		};
+		private static readonly StatType[] SkillStats = new[]
+		{
 			StatType.SkillAthletics,
 			StatType.SkillKnowledgeArcana,
 			StatType.SkillKnowledgeWorld,
@@ -71,11 +108,15 @@ namespace AttributeFeats.New_Feats
 			StatType.SkillStealth,
 			StatType.SkillThievery,
 			StatType.SkillUseMagicDevice,
+		};
 
-			StatType.HitPoints,
-
+		private static readonly StatType[] CasterStats = new[]
+		{
 			StatType.BonusCasterLevel,
 		};
+
+
+
 
 		private static LocalizedString L(string key, string value, bool tagEncyclopediaEntries = true)
 			=> LocalizationTool.CreateString(key, value, tagEncyclopediaEntries);
@@ -154,6 +195,28 @@ namespace AttributeFeats.New_Feats
 
 		}
 
+		private static void AddRank(FeatureConfigurator cfg, StatType stat, ContextRankProgression prog)
+		{
+			// 创建基础配置
+			var config = ContextRankConfigs.StatBonus(stat: stat, min: 0);
+
+			// 根据枚举值，链式调用对应的封装方法
+			switch (prog)
+			{
+				case ContextRankProgression.AsIs:
+					break;
+				case ContextRankProgression.Div2:
+					config.WithDiv2Progression();
+					break;
+				case ContextRankProgression.HalfMore:
+					config.WithHalfMoreProgression();
+					break;
+				default:
+					break;
+			}
+
+			cfg.AddContextRankConfig(config);
+		}
 
 
 
@@ -170,66 +233,76 @@ namespace AttributeFeats.New_Feats
 				.SetDisplayName(L(nameKey, nameValue, tagEncyclopediaEntries: false))
 				.SetDescription(L(descKey, descValue, tagEncyclopediaEntries: true))
 				;
+			var s = Main.Settings;
 
-			foreach (var abil in AbilityStats)
-				cfg.AddDerivativeStatBonus(baseStat: baseStat, descriptor: Desc, derivativeStat: abil);
+			AddRank(cfg, baseStat, s.progression);
 
-
-			cfg.AddContextRankConfig(
-				ContextRankConfigs.StatBonus(stat: baseStat)
-			);
-
-
-			cfg.AddComponent<IncreaseAllSpellsDC>(c =>
-			{
-				c.Value = new ContextValue()
+			Action<StatType[]> addBonuses = (stats) => {
+				foreach (var stat in stats)
 				{
-					ValueType = ContextValueType.Rank, 
-					ValueRank = AbilityRankType.Default
-				};
-				c.Descriptor = Desc;
-				c.SpellsOnly = false;
-			});
-
-			cfg.AddComponent<IncreaseCasterLevel>(c =>
-			{
-				c.Value = new ContextValue()
-				{
-					ValueType = ContextValueType.Rank,
-					ValueRank = AbilityRankType.Default
-				};
-				c.Descriptor = Desc;
-			});
-			cfg.AddComponent<AddSpellResistance>(c =>
-			{
-				c.Value = new ContextValue()
-				{
-					ValueType = ContextValueType.Rank,
-					ValueRank = AbilityRankType.Default
-				};
-			});
-			cfg.AddComponent<SpellPenetrationBonus>(c =>
-			{
-				c.Value = new ContextValue()
-				{
-					ValueType = ContextValueType.Rank,
-					ValueRank = AbilityRankType.Default
-				};
-			});
-
-			cfg.AddComponent<AddAbilityUseTrigger>(c => {
-				c.FromSpellbook = true;
-				c.Action = new ActionList
-				{
-					Actions = new GameAction[] {
-				new ContextActionCastSpell() {
-					MarkAsChild = true,
+					cfg.AddComponent<AddContextStatBonus>(c => {
+						c.Stat = stat;
+						c.Descriptor = Desc;
+						c.Value = new ContextValue { ValueType = ContextValueType.Rank };
+					});
 				}
-		}
-				};
-			});
+			};
+
+			if (s.EnableAttributes) addBonuses(AttributeStats);
+			if (s.EnableBattles) addBonuses(BattleStats);
+			if (s.EnableSavings) addBonuses(SaveStats);
+			if (s.EnableChecks) addBonuses(CheckStats);
+			if (s.EnableSkills) addBonuses(SkillStats);
+
+			if (s.EnableCaster)
+			{
+				addBonuses(CasterStats);
 
 
+				cfg.AddComponent<IncreaseAllSpellsDC>(c =>
+				{
+					c.Value = new ContextValue()
+					{
+						ValueType = ContextValueType.Rank,
+						ValueRank = AbilityRankType.Default
+					};
+					c.Descriptor = Desc;
+					c.SpellsOnly = false;
+				});
+
+				cfg.AddComponent<IncreaseCasterLevel>(c =>
+				{
+					c.Value = new ContextValue()
+					{
+						ValueType = ContextValueType.Rank,
+						ValueRank = AbilityRankType.Default
+					};
+					c.Descriptor = Desc;
+				});
+				cfg.AddComponent<SpellPenetrationBonus>(c =>
+				{
+					c.Value = new ContextValue()
+					{
+						ValueType = ContextValueType.Rank,
+						ValueRank = AbilityRankType.Default
+					};
+				});
+
+
+				cfg.AddComponent<AddAbilityUseTrigger>(c =>
+				{
+					c.FromSpellbook = true;
+					c.Action = new ActionList
+					{
+						Actions = new GameAction[] {
+							new ContextActionCastSpell() {
+								MarkAsChild = true,
+							}
+						}
+					};
+				});
+
+			}
 			cfg.AddRecalculateOnStatChange(stat: baseStat);
 
 


### PR DESCRIPTION

# **Overview**

This PR introduces a comprehensive configuration system via Unity Mod Manager (UMM), addressing user requests for finer control over the mod's power levels. It transitions the mod from a hard-coded "everything-to-everything" buff to a highly customizable attribute engine.

closes #1

## **Key Changes**

### **1. Integrated UMM Settings UI**

* **Feature Toggles:** Added a dedicated settings panel to independently enable/disable specific bonus categories:
* **Ability Score Stacking:** Control whether attributes can boost other attributes.
* **Combat Stats:** Toggle bonuses for AC, BAB, HP, Initiative, etc.
* **Saving Throws:** Toggle Fortitude, Reflex, and Will bonuses.
* **Checks & Skills:** Separate toggles for raw attribute checks and skill proficiencies.
* **Caster Progression:** Control DC, CL, and spell penetration bonuses.

* **Persistence:** Implemented the `ModSettings` class inheriting from `UnityModManager.ModSettings` to handle automatic serialization (Saving/Loading) of user preferences to `settings.xml`.

### **2. Dynamic Progression Scaling**

* **Global Scaling Factor:** Introduced a "Global Progression" selector that utilizes the game's native `ContextRankProgression` logic.
* **Supported Ratios:**
* **100% (AsIs):** Standard 1:1 attribute-to-bonus ratio.
* **50% (Div2):** Balanced 2:1 ratio (e.g., +10 Con grants +5 to other stats).
* **150% (HalfMore):** High-power 1:1.5 ratio for extreme builds.

### **3. Refactored Bonus Logic**

* **Component Migration:** Replaced the static `AddDerivativeStatBonus` with the dynamic `AddContextStatBonus`. This allows the bonuses to respect the `ContextRankConfig` logic defined by the user in the settings menu.


