### PR TITLE
Fixes an XML serialization conflict that prevents Settings.xml from being saved correctly under Unity Mod Manager.

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -9,7 +9,8 @@ namespace AttributeFeats
         Legacy_AllFull,
     }
 
-    [XmlType(Namespace = "AttributeFeats")]
+    [XmlRoot("AttributeFeatsSettings")]
+    [XmlType("AttributeFeatsSettings")]
     public class ModSettings : UnityModManager.ModSettings
     {
         public bool IncludeSelfInAttributeStack = false;


### PR DESCRIPTION
Problem

AttributeFeats.ModSettings inherits from UnityModManager.ModSettings, but both resolve to the same XML type name (ModSettings) during serialization because of:

[XmlType(Namespace = "AttributeFeats")]

This causes:

InvalidOperationException:
Types 'UnityModManagerNet.UnityModManager.ModSettings'
and 'AttributeFeats.ModSettings' both use the XML type name,
'ModSettings', from namespace 'AttributeFeats'.
Fix

Assigned a unique XML root/type name:

[XmlRoot("AttributeFeatsSettings")]
[XmlType("AttributeFeatsSettings")]
Result
Settings.xml now saves correctly
serialization exception no longer occurs
settings persist properly after restart

Tested locally with successful build + settings save/load cycle.